### PR TITLE
ToastView Size をUIScreenではなくUIWindowから取得するように修正

### DIFF
--- a/CRToast/CRToastLayoutHelpers.h
+++ b/CRToast/CRToastLayoutHelpers.h
@@ -69,7 +69,7 @@ static CGFloat CRGetStatusBarHeightForOrientation(UIInterfaceOrientation orienta
 
 /// Get the width of the status bar for given orientation.
 static CGFloat CRGetStatusBarWidthForOrientation(UIInterfaceOrientation orientation) {
-    CGRect mainScreenBounds = [UIScreen mainScreen].bounds;
+    CGRect mainScreenBounds = [UIApplication sharedApplication].windows.firstObject.bounds;
 
     if (CRFrameAutoAdjustedForOrientation()) {
         return CGRectGetWidth(mainScreenBounds);

--- a/CRToast/CRToastViewController.h
+++ b/CRToast/CRToastViewController.h
@@ -6,6 +6,9 @@
 #import <UIKit/UIKit.h>
 @class CRToast;
 
+@interface CRToastContainerView : UIView
+@end
+
 @interface CRToastViewController : UIViewController
 
 @property (nonatomic, assign) BOOL autorotate;

--- a/CRToast/CRToastViewController.m
+++ b/CRToast/CRToastViewController.m
@@ -8,8 +8,6 @@
 #import "CRToastLayoutHelpers.h"
 
 #pragma mark - CRToastContainerView
-@interface CRToastContainerView : UIView
-@end
 
 @implementation CRToastContainerView
 @end

--- a/CRToast/CRToastWindow.m
+++ b/CRToast/CRToastWindow.m
@@ -4,6 +4,7 @@
 //
 
 #import "CRToastWindow.h"
+#import "CRToastViewController.h"
 
 @implementation CRToastWindow
 
@@ -14,6 +15,18 @@
         }
     }
     return NO;
+}
+
+// FIXME:
+// Xcode/iOS13 iPad で Toast を表示すると UIWindow 内の Subview にイベントが反応し、
+// Main Window の UI が操作できなくなるため、Toast 箇所以外のビューがタップされた場合は透過するように調整
+// 一時的な対応なので 本ライブラリ自体差し替えを検討する必要がある
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hitView = [super hitTest:point withEvent:event];
+    if ([hitView isKindOfClass:CRToastContainerView.class]) {
+        return hitView;
+    }
+    return nil;
 }
 
 @end


### PR DESCRIPTION
# 対応メモ

## Issues
Xcode/iOS13 iPad で Toast を表示すると UIWindow 内の Subview にイベントが反応して、その下の階層にあるMain Window の UI が操作できなくなっていた。
<img width="446" alt="スクリーンショット 2020-03-05 17 38 44" src="https://user-images.githubusercontent.com/7993421/75963140-56459800-5f08-11ea-83b1-3754ec9c59e4.png">

## Fix
Toast _表示時に、イベントのハンドリングを行っている CRToastContainerView 以外のサブビューがタップされた場合はイベントを透過するように hitTestメソッドをオーバーライドして回避した。

とはいえ、かなり一時的な対応なので早急に本ライブラリ自体差し替えを検討する必要がある